### PR TITLE
fix pytorch pau cuda import

### DIFF
--- a/pau_torch/pade_cuda_functions.py
+++ b/pau_torch/pade_cuda_functions.py
@@ -1,6 +1,6 @@
 import torch
 
-from pau_cuda import *
+from cuda import *
 
 
 class PAU_CUDA_A_F(torch.autograd.Function):


### PR DESCRIPTION
"pau_cuda" has been refactored to "cuda" but the import has not been changed